### PR TITLE
Allow 0 valued traits

### DIFF
--- a/bullet_train/bullet_train.py
+++ b/bullet_train/bullet_train.py
@@ -141,7 +141,8 @@ class BulletTrain:
         :param trait_value: value of trait
         :param identity: application's unique identifier for the user to check feature state
         """
-        if not all([trait_key, trait_value, identity]):
+        values = [trait_key, trait_value, identity]
+        if None in values or '' in values:
             return None
 
         payload = {


### PR DESCRIPTION
The current `set_trait` implementation don't allow to set traits with the value 0 (e.g. a trait storing an user's purchase count)